### PR TITLE
Add warning about file_server directive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ cgi /script.cgi* /path/to/my/script someargument {
 }
 ```
 
+Also note that in Caddy v2 there is a behavior change when using the `file_server` directive which makes it incompatible with cgi without special handling. The symptom is that the path to the cgi will not be found which results in a 404 error. To make it work with file_server requires that the cgi directive be embedded within a `handle` directive that uses the same [matcher] for its argument, for example:
+
+``` caddy
+file_server
+handle /report {
+  cgi /report /usr/local/cgi-bin/report
+}
+```
+
 ### Advanced Syntax
 
 In order to specify custom environment variables, pass along one or more


### PR DESCRIPTION
I ran into an issue when using the file_server directive where the cgi would only return 404 errors, not being able to find the path. The proposed change to the README gives a warning about the case and an example on how to work around it using the handle directive.  This was a caddy v2 change because in v1 this workaround was not required.